### PR TITLE
fix: defer after err, get contract origin, handle errs

### DIFF
--- a/pkg/api/getContractInfo.go
+++ b/pkg/api/getContractInfo.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"encoding/json"
+)
+
+type ContractInfoResponse struct {
+	Runtimecode   string `json:"runtimecode"`
+	SmartContract struct {
+		ConsumeUserResourcePercent int    `json:"consume_user_resource_percent"`
+		OriginAddress              string `json:"origin_address"`
+		ContractAddress            string `json:"contract_address"`
+		CodeHash                   string `json:"code_hash"`
+	} `json:"smart_contract"`
+}
+
+func (a *Api) GetContractInfo(token *Address) (ContractInfoResponse, error) {
+	postBody, _ := json.Marshal(map[string]interface{}{
+		"value":   token.ToHex(),
+		"visible": "false",
+	})
+
+	res, err := a.provider.Request(a.provider.GetContractInfo(), postBody)
+	if err != nil {
+		a.log.Error(err.Error())
+		return ContractInfoResponse{}, err
+	}
+
+	defer res.Body.Close()
+
+	var data ContractInfoResponse
+	decoder := json.NewDecoder(res.Body)
+	err = decoder.Decode(&data)
+	if err != nil {
+		return ContractInfoResponse{}, err
+	}
+
+	return data, nil
+}

--- a/pkg/api/getContractInfo_test.go
+++ b/pkg/api/getContractInfo_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"github.com/kattana-io/tron-objects-api/pkg/url"
+	"go.uber.org/zap"
+	"testing"
+)
+
+func TestApi_GetContractInfo(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	type fields struct {
+		endpoint string
+		log      *zap.Logger
+		provider url.ApiUrlProvider
+	}
+	type args struct {
+		token *Address
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Sunswap factory origin",
+			fields: fields{
+				endpoint: "https://api.trongrid.io",
+				log:      logger,
+				provider: url.NewTrongridUrlProvider(),
+			},
+			args: args{
+				token: FromHex("41a2726afbecbd8e936000ed684cef5e2f5cf43008"),
+			},
+			want:    "41eed9e56a5cddaa15ef0c42984884a8afcf1bdebb",
+			wantErr: false,
+		},
+		{
+			name: "Justmoney factory origin",
+			fields: fields{
+				endpoint: "https://api.trongrid.io",
+				log:      logger,
+				provider: url.NewTrongridUrlProvider(),
+			},
+			args: args{
+				token: FromHex("412e12cbc3bacb0a80aef95b320773a7c64bc4372d"),
+			},
+			want:    "411294fce9b5932fc8c289fa1059a8b0b0a9f6daf5",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Api{
+				endpoint: tt.fields.endpoint,
+				log:      tt.fields.log,
+				provider: tt.fields.provider,
+			}
+			got, err := a.GetContractInfo(tt.args.token)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetContractInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got.SmartContract.OriginAddress != tt.want {
+				t.Errorf("Mismatch response: %s got %s", got.SmartContract.OriginAddress, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/triggerConstantContract.go
+++ b/pkg/api/triggerConstantContract.go
@@ -53,12 +53,12 @@ func (a *Api) TriggerConstantContract(contractAddress string, functionSelector s
 	})
 
 	res, err := a.provider.Request(a.provider.TriggerConstantContract(), postBody)
-	defer res.Body.Close()
-
 	if err != nil {
 		a.log.Error(err.Error())
 		return &TCCResponse{}, err
 	}
+
+	defer res.Body.Close()
 
 	var data TCCResponse
 	decoder := json.NewDecoder(res.Body)
@@ -78,12 +78,12 @@ func (a *Api) GetTokenDecimals(token string) (int32, error) {
 	})
 
 	res, err := a.provider.Request(a.provider.TriggerConstantContract(), postBody)
-	defer res.Body.Close()
-
 	if err != nil {
 		a.log.Error(err.Error())
 		return 18, err
 	}
+
+	defer res.Body.Close()
 
 	var data TCCResponse
 	decoder := json.NewDecoder(res.Body)
@@ -107,12 +107,11 @@ func (a *Api) GetPairToken(pair string) (string, error) {
 	})
 
 	res, err := a.provider.Request(a.provider.TriggerConstantContract(), postBody)
-	defer res.Body.Close()
-
 	if err != nil {
 		a.log.Error(err.Error())
 		return "", err
 	}
+	defer res.Body.Close()
 
 	var data TCCResponse
 	decoder := json.NewDecoder(res.Body)
@@ -131,12 +130,12 @@ func (a *Api) GetToken0(pair string) (string, error) {
 	})
 
 	res, err := a.provider.Request(a.provider.TriggerConstantContract(), postBody)
-	defer res.Body.Close()
-
 	if err != nil {
 		a.log.Error(err.Error())
 		return "", err
 	}
+
+	defer res.Body.Close()
 
 	var data TCCResponse
 	decoder := json.NewDecoder(res.Body)
@@ -156,12 +155,11 @@ func (a *Api) GetToken1(pair string) (string, error) {
 	})
 
 	res, err := a.provider.Request(a.provider.TriggerConstantContract(), postBody)
-	defer res.Body.Close()
-
 	if err != nil {
 		a.log.Error(err.Error())
 		return "", err
 	}
+	defer res.Body.Close()
 
 	var data TCCResponse
 	decoder := json.NewDecoder(res.Body)
@@ -182,12 +180,11 @@ func (a *Api) GetTokenName(hexAddress string) (string, error) {
 	responseBody := bytes.NewBuffer(postBody)
 
 	res, err := http.Post(a.provider.TriggerConstantContract(), "application/json", responseBody)
-	defer res.Body.Close()
-
 	if err != nil {
 		a.log.Error(err.Error())
 		return "", err
 	}
+	defer res.Body.Close()
 
 	var data TCCResponse
 	decoder := json.NewDecoder(res.Body)
@@ -215,12 +212,11 @@ func (a *Api) GetTokenSymbol(hexAddress string) (string, error) {
 	responseBody := bytes.NewBuffer(postBody)
 
 	res, err := http.Post(a.provider.TriggerConstantContract(), "application/json", responseBody)
-	defer res.Body.Close()
-
 	if err != nil {
 		a.log.Error(err.Error())
 		return "", err
 	}
+	defer res.Body.Close()
 
 	var data TCCResponse
 	decoder := json.NewDecoder(res.Body)

--- a/pkg/justmoney/Pair.go
+++ b/pkg/justmoney/Pair.go
@@ -1,6 +1,9 @@
 package justmoney
 
-import "github.com/kattana-io/tron-objects-api/pkg/api"
+import (
+	"errors"
+	"github.com/kattana-io/tron-objects-api/pkg/api"
+)
 
 type Pair struct {
 	api     *api.Api
@@ -17,7 +20,10 @@ func New(api *api.Api, address api.Address) *Pair {
 func (s *Pair) Token0() (*api.Address, error) {
 	res, err := s.api.GetToken0(s.address.ToHex())
 	if err != nil {
-		return api.FromHex("0x0"), err
+		return api.EmptyAddress(), err
+	}
+	if res == "" {
+		return api.EmptyAddress(), errors.New(" not a justmoney pair")
 	}
 	return api.FromHex(res), nil
 }
@@ -25,7 +31,10 @@ func (s *Pair) Token0() (*api.Address, error) {
 func (s *Pair) Token1() (*api.Address, error) {
 	res, err := s.api.GetToken1(s.address.ToHex())
 	if err != nil {
-		return api.FromHex("0x0"), err
+		return api.EmptyAddress(), err
+	}
+	if res == "" {
+		return api.EmptyAddress(), errors.New(" not a justmoney pair")
 	}
 	return api.FromHex(res), nil
 }

--- a/pkg/justmoney/Pair_test.go
+++ b/pkg/justmoney/Pair_test.go
@@ -26,6 +26,33 @@ func TestPair_Token0(t *testing.T) {
 			want:    "TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR",
 			wantErr: false,
 		},
+		{
+			name: "TRX/USDT",
+			fields: fields{
+				api:     api.NewApi("", nil, url.NewTrongridUrlProvider()),
+				address: *api.FromBase58("TYA7DfE44XFsZEpBm7M2HAmEgU5kCtDDXg"),
+			},
+			want:    "TNUC9Qb1rRpS5CbWLmNMxXBjyFoydXjWFR",
+			wantErr: false,
+		},
+		{
+			name: "PROS/TRX",
+			fields: fields{
+				api:     api.NewApi("", nil, url.NewTrongridUrlProvider()),
+				address: *api.FromBase58("TA7hPWMWPWoadfFKWpTAdPYVZd3SNdtBDE"),
+			},
+			want:    "TFf1aBoNFqxN32V2NQdvNrXVyYCy9qY8p1",
+			wantErr: false,
+		},
+		{
+			name: "(Not a justmoney pair) AOT/TRX",
+			fields: fields{
+				api:     api.NewApi("", nil, url.NewTrongridUrlProvider()),
+				address: *api.FromBase58("TUer6gnscMcEX8Pid2FtwBCCS4coKRCrtL"),
+			},
+			want:    "1111",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/sunswap/Pair.go
+++ b/pkg/sunswap/Pair.go
@@ -1,6 +1,9 @@
 package sunswap
 
-import "github.com/kattana-io/tron-objects-api/pkg/api"
+import (
+	"errors"
+	"github.com/kattana-io/tron-objects-api/pkg/api"
+)
 
 type Pair struct {
 	api     *api.Api
@@ -18,6 +21,9 @@ func (s *Pair) GetTokenAddress() (*api.Address, error) {
 	res, err := s.api.GetPairToken(s.address.ToHex())
 	if err != nil {
 		return api.EmptyAddress(), err
+	}
+	if res == "" {
+		return api.EmptyAddress(), errors.New("returned nil address")
 	}
 	return api.FromHex(res), nil
 }

--- a/pkg/sunswap/Pair_test.go
+++ b/pkg/sunswap/Pair_test.go
@@ -15,6 +15,7 @@ func TestSunswapPair_GetTokenAddress(t *testing.T) {
 		name   string
 		fields fields
 		want   string
+		error  bool
 	}{
 		{
 			name: "USDT/TRX",
@@ -22,7 +23,8 @@ func TestSunswapPair_GetTokenAddress(t *testing.T) {
 				api:     api.NewApi("", nil, url.NewTrongridUrlProvider()),
 				address: *api.FromBase58("TQn9Y2khEsLJW1ChVWFMSMeRDow5KcbLSE"),
 			},
-			want: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+			want:  "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+			error: false,
 		},
 		{
 			name: "KBC/TRX",
@@ -30,7 +32,8 @@ func TestSunswapPair_GetTokenAddress(t *testing.T) {
 				api:     api.NewApi("", nil, url.NewTrongridUrlProvider()),
 				address: *api.FromBase58("TLP9cpp3B8WQNUXgbvjuYvvWUpmA4bzv4V"),
 			},
-			want: "TUGrjLMegH5jvnaS2at6inkmNAWvtqTRFa",
+			want:  "TUGrjLMegH5jvnaS2at6inkmNAWvtqTRFa",
+			error: false,
 		},
 		{
 			name: "BAGH/TRX",
@@ -38,7 +41,8 @@ func TestSunswapPair_GetTokenAddress(t *testing.T) {
 				api:     api.NewApi("", nil, url.NewTrongridUrlProvider()),
 				address: *api.FromBase58("TLYE9Qz3Kue6EV8Na5aNki9Jkk8rZHp8Yo"),
 			},
-			want: "TKZyr8jUu3aZZtUNQ6cRzML91oPUvUKxEJ",
+			want:  "TKZyr8jUu3aZZtUNQ6cRzML91oPUvUKxEJ",
+			error: false,
 		},
 		{
 			name: "BC/TRX",
@@ -46,7 +50,8 @@ func TestSunswapPair_GetTokenAddress(t *testing.T) {
 				api:     api.NewApi("", nil, url.NewTrongridUrlProvider()),
 				address: *api.FromBase58("TLZbTD6Yg6iBWX6wKvYAsxE83vwweRVtuU"),
 			},
-			want: "TJ7s4HjC1dYapZZnMq96VD6XcEEH3GKx1x",
+			want:  "TJ7s4HjC1dYapZZnMq96VD6XcEEH3GKx1x",
+			error: false,
 		},
 		{
 			name: "META/TRX",
@@ -54,7 +59,17 @@ func TestSunswapPair_GetTokenAddress(t *testing.T) {
 				api:     api.NewApi("", nil, url.NewTrongridUrlProvider()),
 				address: *api.FromBase58("TLaeHRNDoP2YaccQwqzYJdJjwfzJ6DcKR5"),
 			},
-			want: "TPvyF8CD6eknF7hgfoZgZ9capryqQALQ52",
+			want:  "TPvyF8CD6eknF7hgfoZgZ9capryqQALQ52",
+			error: false,
+		},
+		{
+			name: "(Not sunswap pair) MEOX/JM",
+			fields: fields{
+				api:     api.NewApi("", nil, url.NewTrongridUrlProvider()),
+				address: *api.FromBase58("TMS2EaT8oKQcNmrbjArhi1umN1kFStRqrj"),
+			},
+			want:  "",
+			error: true,
 		},
 	}
 	for _, tt := range tests {
@@ -63,7 +78,9 @@ func TestSunswapPair_GetTokenAddress(t *testing.T) {
 				api:     tt.fields.api,
 				address: tt.fields.address,
 			}
-			if got, _ := s.GetTokenAddress(); got.ToBase58() != tt.want {
+			got, err := s.GetTokenAddress()
+			hasErr := err != nil
+			if got.ToBase58() != tt.want && hasErr != tt.error {
 				t.Errorf("GetTokenAddress() = %v, want %v", got.ToBase58(), tt.want)
 			}
 		})

--- a/pkg/url/node.go
+++ b/pkg/url/node.go
@@ -11,10 +11,15 @@ type ApiUrlProvider interface {
 	GetBlockByNum() string
 	GetTransactionInfoById() string
 	TriggerConstantContract() string
+	GetContractInfo() string
 }
 
 type NodeUrlProvider struct {
 	host string
+}
+
+func (n *NodeUrlProvider) GetContractInfo() string {
+	return fmt.Sprintf("%s/wallet/getcontractinfo", n.host)
 }
 
 func (n *NodeUrlProvider) GetBlockByNum() string {

--- a/pkg/url/trongrid.go
+++ b/pkg/url/trongrid.go
@@ -44,3 +44,7 @@ func (n *TrongridUrlProvider) GetTransactionInfoById() string {
 func (n *TrongridUrlProvider) TriggerConstantContract() string {
 	return "https://api.trongrid.io/wallet/triggerconstantcontract"
 }
+
+func (n *TrongridUrlProvider) GetContractInfo() string {
+	return "https://api.trongrid.io/wallet/getcontractinfo"
+}


### PR DESCRIPTION
* Call defer only after err != nil
* Created method to get contract origin
* Additional handle errors for justmoney, sunswap pair classes
* new test cases